### PR TITLE
Add status_compaction callbacks for #671

### DIFF
--- a/src/leo_backend_db_api.erl
+++ b/src/leo_backend_db_api.erl
@@ -32,7 +32,7 @@
 -export([new/4, new/5,
          put/3, get/2, delete/2, fetch/3, fetch/4, first/1,
          status/1,
-         run_compaction/1, finish_compaction/2,
+         run_compaction/1, finish_compaction/2, status_compaction/1,
          put_value_to_new_db/3,
          get_db_raw_filepath/1,
          has_instance/1,
@@ -210,6 +210,20 @@ status(InstanceName) ->
                         end, [], List)
     end.
 
+%% @doc Retrieve compaction status from backend-db.
+%%
+-spec(status_compaction(InstanceName) ->
+             [{atom(), term()}] when InstanceName::atom()).
+status_compaction(InstanceName) ->
+    case ets:lookup(?ETS_TABLE_NAME, InstanceName) of
+        [] ->
+            not_found;
+        [{InstanceName, List}] ->
+            lists:foldl(fun(Id, Acc) ->
+                                Res = ?SERVER_MODULE:status_compaction(Id),
+                                [Res|Acc]
+                        end, [], List)
+    end.
 
 %% @doc Start the data-compaction
 -spec(run_compaction(InstanceName) ->

--- a/src/leo_backend_db_eleveldb.erl
+++ b/src/leo_backend_db_eleveldb.erl
@@ -29,6 +29,7 @@
 
 -export([open/1, open/2, close/1]).
 -export([get/2, put/3, delete/2, prefix_search/4, first/1]).
+-export([status_compaction/1]).
 
 -define(ETS_TBL_LEVELDB, 'leo_eleveldb').
 -define(ETS_COL_LEVELDB_KEY_CNT, 'key_count').
@@ -100,6 +101,13 @@ close(Handler) ->
     catch eleveldb:close(Handler),
     ok.
 
+%% @doc Retrieve the compaction status
+%%
+-spec(status_compaction(Handler) ->
+             binary() when Handler::eleveldb:db_ref()).
+status_compaction(Handler) ->
+    {ok, Ret} = eleveldb:status(Handler, <<"leveldb.stats">>),
+    Ret.
 
 %% @doc Retrieve an object from the eleveldb.
 %%

--- a/test/leo_backend_db_api_tests.erl
+++ b/test/leo_backend_db_api_tests.erl
@@ -174,6 +174,15 @@ inspect(Instance, BackendDb, Path) ->
         _ ->
             void
     end,
+
+    %% %4 status_compaction
+    [SCH|_] = leo_backend_db_api:status_compaction(Instance),
+    case BackendDb of
+        ?BACKEND_DB_LEVELDB ->
+            ?assertEqual(true, is_binary(SCH));
+        _ ->
+            ?assertEqual({error, unsupported}, SCH)
+    end,
     ok.
 
 


### PR DESCRIPTION
Enable to retrieve compaction related info like below.
```erlang
(storage_0@127.0.0.1)14> [B] = leo_backend_db_api:status_compaction(leo_metadata_0).
<""
Compactions
Level  Files Size(MB) Time(sec) Read(MB) Write(MB)
------------------------------------------------------
0        2       10         0        0        10
1        1        0         0        0         0
2        1        0         0        0         0
">>
```