### PR TITLE
Count the number by iterating eleveldb if no state file exist

### DIFF
--- a/src/leo_backend_db_api.erl
+++ b/src/leo_backend_db_api.erl
@@ -32,6 +32,7 @@
 -export([new/4, new/5,
          put/3, get/2, delete/2, fetch/3, fetch/4, first/1, first_n/2,
          status/1,
+         count/1,
          run_compaction/1, finish_compaction/2, status_compaction/1,
          put_value_to_new_db/3,
          get_db_raw_filepath/1,
@@ -239,6 +240,22 @@ status(InstanceName) ->
                                 Res = ?SERVER_MODULE:status(Id),
                                 [Res|Acc]
                         end, [], List)
+    end.
+
+%% @doc Count the number of records from backend-db.
+%%
+-spec(count(InstanceName) ->
+             Count when Count::non_neg_integer(),
+                              InstanceName::atom()).
+count(InstanceName) ->
+    case ets:lookup(?ETS_TABLE_NAME, InstanceName) of
+        [] ->
+            0;
+        [{InstanceName, List}] ->
+            lists:foldl(fun(Id, Acc) ->
+                                {ok, Count} = ?SERVER_MODULE:count(Id),
+                                Acc + Count
+                        end, 0, List)
     end.
 
 %% @doc Retrieve compaction status from backend-db.

--- a/src/leo_backend_db_eleveldb.erl
+++ b/src/leo_backend_db_eleveldb.erl
@@ -29,6 +29,7 @@
 
 -export([open/1, open/2, close/1]).
 -export([get/2, put/3, delete/2, prefix_search/4, first/1, first_n/2]).
+-export([count/1]).
 -export([status_compaction/1]).
 
 -define(ETS_TBL_LEVELDB, 'leo_eleveldb').
@@ -284,6 +285,33 @@ first_n(Handler, N) ->
             error_logger:error_msg("~p,~p,~p,~p~n",
                                    [{module, ?MODULE_STRING},
                                     {function, "first_n/2"},
+                                    {line, ?LINE}, {body, Cause}]),
+            {error, Cause}
+    end.
+
+%% @doc Count the number of records from eleveldb.
+%%
+-spec(count(Handler) ->
+             {ok, Count} | {error, any()} when Handler::eleveldb:db_ref(),
+                                               Count::non_neg_integer()).
+count(Handler) ->
+    %% Function to count the number of records
+    Fun = fun({_K, _V}, Acc) ->
+                  {false, Acc + 1}
+          end,
+    case catch fold(Handler, Fun, 0, []) of
+        {ok, Count} ->
+            {ok, Count};
+        {'EXIT', Cause} ->
+            error_logger:error_msg("~p,~p,~p,~p~n",
+                                   [{module, ?MODULE_STRING},
+                                    {function, "count/1"},
+                                    {line, ?LINE}, {body, Cause}]),
+            {error, Cause};
+        {error, Cause} ->
+            error_logger:error_msg("~p,~p,~p,~p~n",
+                                   [{module, ?MODULE_STRING},
+                                    {function, "count/1"},
                                     {line, ?LINE}, {body, Cause}]),
             {error, Cause}
     end.


### PR DESCRIPTION
This is the Fix for https://github.com/leo-project/leofs/issues/731.
With this PR, leo_backend_db can keep holding the exact number of records even without a state file.