### PR TITLE
Fix to make the error message readable for #872

### DIFF
--- a/src/leo_backend_db_eleveldb.erl
+++ b/src/leo_backend_db_eleveldb.erl
@@ -25,6 +25,7 @@
 -module(leo_backend_db_eleveldb).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("leo_commons/include/leo_commons.hrl").
 -include("leo_backend_db.hrl").
 
 -export([open/1, open/2, close/1]).
@@ -61,7 +62,7 @@ open(Path, Config) ->
                {sst_block_size, BlockSize}
               ],
 
-    case filelib:ensure_dir(Path) of
+    case leo_file:ensure_dir(Path) of
         ok ->
             open_1(Path, Options);
         {error, Cause} ->

--- a/src/leo_backend_db_server.erl
+++ b/src/leo_backend_db_server.erl
@@ -29,6 +29,7 @@
 -behaviour(gen_server).
 
 -include("leo_backend_db.hrl").
+-include_lib("leo_commons/include/leo_commons.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 %% API
@@ -377,7 +378,7 @@ handle_call(count, _From, State) ->
 handle_call(run_compaction, _From, #state{db = DBModule,
                                           path = Path} = State) ->
     NewPath = gen_file_raw_path(Path),
-    case filelib:ensure_dir(NewPath) of
+    case leo_file:ensure_dir(NewPath) of
         ok ->
             case DBModule:open(NewPath) of
                 {ok, NewHandler} ->
@@ -484,7 +485,7 @@ get_raw_path(SymLinkPath) ->
             {ok, FileName};
         {error, enoent} ->
             RawPath = gen_file_raw_path(SymLinkPath),
-            case filelib:ensure_dir(RawPath) of
+            case leo_file:ensure_dir(RawPath) of
                 ok ->
                     case file:make_symlink(RawPath, SymLinkPath) of
                         ok ->


### PR DESCRIPTION
- Before
```erlang
[E]     storage_0@127.0.0.1     2017-11-02 15:23:33.294359 +0900        1509603813      leo_storage_app:launch_object_storage    292     CRASH REPORT Process <0.49.0> with 0 neighbours exited with reason: no mat
ch of right hand value {error,{{'EXIT',invalid_launch},{child,undefined,leo_object_storage_sup,{leo_object_storage_sup,start_link,[[{8,"/mnt/leofs"}],leo_storage_msg_collector]},permanent,2000,supervisor,[leo_ob
ject_storage_sup]}}} in leo_storage_app:launch_object_storage/1 line 292 in application_master:init/4 line 134
[E]     storage_0@127.0.0.1     2017-11-02 15:23:38.55047 +0900 1509603818      null:null       0       CRASH REPORT Process <0.113.0> with 0 neighbours exited with reason: enoent in gen_server:init_it/6 line 34
9
```
- After
```erlang
[E]     storage_0@127.0.0.1     2017-11-02 15:45:14.167734 +0900        1509605114      leo_storage_app:launch_object_storage   292     CRASH REPORT Process <0.50.0> with 0 neighbours exited with reason: no matc
h of right hand value {error,{{'EXIT',invalid_launch},{child,undefined,leo_object_storage_sup,{leo_object_storage_sup,start_link,[[{8,"/mnt/leofs/avs"}],leo_storage_msg_collector]},permanent,2000,supervisor,[leo
_object_storage_sup]}}} in leo_storage_app:launch_object_storage/1 line 292 in application_master:init/4 line 134
[E]     storage_0@127.0.0.1     2017-11-02 15:45:19.463534 +0900        1509605119      null:null       0       {module,"leo_file"},{function,"ensure_dir/1"},{line,298},{body,{file,"/mnt/leofs/avs/metadata"},{re
sult,eacces}}
```

Related PR
- https://github.com/leo-project/leo_object_storage/pull/15