### PR TITLE
Change the owner of ets to the supervisor as the caller can be an ephemeral process

### DIFF
--- a/src/leo_backend_db_sup.erl
+++ b/src/leo_backend_db_sup.erl
@@ -86,6 +86,14 @@ start_child(SupRef, InstanceName, NumOfDBProcs,
             BackendDB, DBRootPath, IsStrictCheck) ->
     ok = leo_misc:init_env(),
     catch ets:new(?ETS_TABLE_NAME, [named_table, public, {read_concurrency, true}]),
+    %% Necessary as the caller process is ephemeral (being terminated immediately)
+    SupPid = case is_atom(SupRef) of
+                 true ->
+                     whereis(SupRef);
+                 false ->
+                     SupRef
+             end,
+    catch ets:give_away(?ETS_TABLE_NAME, SupPid, []),
     start_child_1(SupRef, InstanceName, NumOfDBProcs - 1, (NumOfDBProcs == 1),
                   BackendDB, DBRootPath, IsStrictCheck, []).
 


### PR DESCRIPTION
This PR should be merged before the PR on leo_object_storage (https://github.com/leo-project/leo_object_storage/pull/16) get merged.